### PR TITLE
Small Fixes

### DIFF
--- a/README
+++ b/README
@@ -30,7 +30,7 @@ CREATE TABLE users (
 	inebriation int NOT NULL DEFAULT '0',
 	faction varchar(32) NOT NULL default '',
 	poi varchar(64) NOT NULL default 'downtown',
-	life_state int NOT NULL DEFAULT '0',
+	life_state int NOT NULL DEFAULT '1',
 	busted int NOT NULL DEFAULT '0',
 	
 	CONSTRAINT id_user_server PRIMARY KEY (id_user, id_server)
@@ -56,6 +56,7 @@ CREATE TABLE markets (
 	negaslime bigint NOT NULL DEFAULT '0',
 	clock int NOT NULL DEFAULT '0',
 	weather varchar(32) NOT NULL DEFAULT 'sunny',
+	day int NOT NULL DEFAULT '726',
 
 	PRIMARY KEY (id_server)
 );

--- a/README
+++ b/README
@@ -56,7 +56,7 @@ CREATE TABLE markets (
 	negaslime bigint NOT NULL DEFAULT '0',
 	clock int NOT NULL DEFAULT '0',
 	weather varchar(32) NOT NULL DEFAULT 'sunny',
-	day int NOT NULL DEFAULT '726',
+	day int NOT NULL DEFAULT '727',
 
 	PRIMARY KEY (id_server)
 );

--- a/client.py
+++ b/client.py
@@ -331,6 +331,7 @@ async def on_ready():
 
 					if market_data.clock >= 24 or market_data.clock < 0:
 						market_data.clock = 0
+						market_data.day += 1
 
 					if random.randrange(30) == 0:
 						pattern_count = len(ewcfg.weather_list)

--- a/ew.py
+++ b/ew.py
@@ -9,6 +9,7 @@ class EwMarket:
 
 	clock = 0
 	weather = 'sunny'
+	day = 0
 	
 	slimes_casino = 0
 	slimes_revivefee = 0
@@ -30,7 +31,7 @@ class EwMarket:
 				cursor = conn.cursor();
 
 				# Retrieve object
-				cursor.execute("SELECT {}, {}, {}, {}, {}, {}, {}, {}, {} FROM markets WHERE id_server = %s".format(
+				cursor.execute("SELECT {}, {}, {}, {}, {}, {}, {}, {}, {}, {} FROM markets WHERE id_server = %s".format(
 					ewcfg.col_slimes_casino,
 					ewcfg.col_rate_market,
 					ewcfg.col_rate_exchange,
@@ -40,6 +41,7 @@ class EwMarket:
 					ewcfg.col_negaslime,
 					ewcfg.col_clock,
 					ewcfg.col_weather,
+					ewcfg.col_day
 				), (self.id_server, ))
 				result = cursor.fetchone();
 
@@ -54,6 +56,7 @@ class EwMarket:
 					self.negaslime = result[6]
 					self.clock = result[7]
 					self.weather = result[8]
+					self.day = result[9]
 				else:
 					# Create a new database entry if the object is missing.
 					cursor.execute("REPLACE INTO markets(id_server) VALUES(%s)", (id_server, ))
@@ -72,7 +75,7 @@ class EwMarket:
 			cursor = conn.cursor();
 
 			# Save the object.
-			cursor.execute("REPLACE INTO markets({}, {}, {}, {}, {}, {}, {}, {}, {}, {}) VALUES(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)".format(
+			cursor.execute("REPLACE INTO markets({}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}) VALUES(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)".format(
 				ewcfg.col_id_server,
 				ewcfg.col_slimes_casino,
 				ewcfg.col_rate_market,
@@ -82,7 +85,8 @@ class EwMarket:
 				ewcfg.col_slimes_revivefee,
 				ewcfg.col_negaslime,
 				ewcfg.col_clock,
-				ewcfg.col_weather
+				ewcfg.col_weather,
+				ewcfg.col_day
 			), (
 				self.id_server,
 				self.slimes_casino,
@@ -93,7 +97,8 @@ class EwMarket:
 				self.slimes_revivefee,
 				self.negaslime,
 				self.clock,
-				self.weather
+				self.weather,
+				self.day
 			))
 
 			conn.commit()

--- a/ewcasino.py
+++ b/ewcasino.py
@@ -5,7 +5,7 @@ import time
 import ewcmd
 import ewutils
 import ewcfg
-from ew import EwUser, EwMarket
+from ew import EwUser
 
 # Map containing user IDs and the last time in UTC seconds since the pachinko
 # machine was used.
@@ -44,14 +44,9 @@ async def pachinko(cmd):
 		last_pachinkoed_times[cmd.message.author.id] = time_now
 		value = ewcfg.slimes_perpachinko
 
-		market_data = EwMarket(id_server = cmd.message.server.id)
 		user_data = EwUser(member = cmd.message.author)
 
-		if ewcmd.is_casino_open(market_data.clock) == False:
-			response = ewcfg.str_casino_closed
-		elif user_data.life_state == ewcfg.life_state_corpse:
-			response = "{}our incorporeal existence leaves you unable to load the balls into the slime pachinko machine.".format(("Try as you may, y" if random.randrange(2) == 0 else "Y"))
-		elif value > user_data.slimecredit:
+		if value > user_data.slimecredit:
 			response = "You don't have enough SlimeCoin to play."
 		else:
 			#subtract slimecoin from player
@@ -131,17 +126,9 @@ async def craps(cmd):
 
 		if value != None:
 			user_data = EwUser(member = cmd.message.author)
-			market_data = EwMarket(id_server = cmd.message.author.server.id)
 
 			if value == -1:
 				value = user_data.slimecredit
-
-			if ewcmd.is_casino_open(market_data.clock) == False:
-				response = ewcfg.str_casino_closed
-			elif user_data.life_state == ewcfg.life_state_corpse:
-				response = "You paw at the dice to no avail."
-				if random.randrange(2) == 0:
-					response += " Your transparent mitts cast your influence as strongly as your shadow."
 
 			elif value > user_data.slimecredit:
 				response = "You don't have that much SlimeCoin to bet with."
@@ -170,7 +157,6 @@ async def craps(cmd):
 					response += "\n\nYou didn't roll 7. You lost your SlimeCoins."
 
 				user_data.persist()
-				market_data.persist()
 		else:
 			response = "Specify how much SlimeCoin you will wager."
 
@@ -198,13 +184,8 @@ async def slots(cmd):
 		last_slotsed_times[cmd.message.author.id] = time_now
 
 		user_data = EwUser(member = cmd.message.author)
-		market_data = EwMarket(id_server = cmd.message.author.server.id)
 
-		if ewcmd.is_casino_open(market_data.clock) == False:
-			response = ewcfg.str_casino_closed
-		elif user_data.life_state == ewcfg.life_state_corpse:
-			response = "Your ghostly appendage falls through the lever, failing to start the slot machine."
-		elif value > user_data.slimecredit:
+		if value > user_data.slimecredit:
 			response = "You don't have enough SlimeCoin."
 		else:
 			#subtract slimecoin from player
@@ -329,16 +310,11 @@ async def roulette(cmd):
 
 		if value != None:
 			user_data = EwUser(member = cmd.message.author)
-			market_data = EwMarket(id_server = cmd.message.author.server.id)
 
 			if value == -1:
 				value = user_data.slimecredit
 
-			if ewcmd.is_casino_open(market_data.clock) == False:
-				response = ewcfg.str_casino_closed
-			elif user_data.life_state == ewcfg.life_state_corpse:
-				response = "Your silent, ghastly wails fail to attract the attention of the croupier."
-			elif value > user_data.slimecredit or value == 0:
+			if value > user_data.slimecredit or value == 0:
 				response = "You don't have enough SlimeCoin."
 			elif len(bet) == 0:
 				response = "You need to say what you're betting on. Options are: {}\n{}board.png".format(ewutils.formatNiceList(names = all_bets), img_base)

--- a/ewcfg.py
+++ b/ewcfg.py
@@ -216,6 +216,7 @@ emote_purple = "<:purple:496397848343216138>"
 emote_pink = "<:pink:496397871180939294>"
 emote_slimecoin = "<:slimecoin:440576133214240769>"
 emote_slimegun = "<:slimegun:436500203743477760>"
+emote_testemote = "<:purple:496348895098699796>" # test server emote 
 
 # Emotes for the negaslime writhe animation
 emote_vt = "<:vt:492067858160025600>"
@@ -298,6 +299,7 @@ col_slimes_revivefee = 'slimes_revivefee'
 col_negaslime = 'negaslime'
 col_clock = 'clock'
 col_weather = 'weather'
+col_day = 'day'
 
 # Database columns for stats
 col_total_slime = 'total_slime'
@@ -553,6 +555,8 @@ weapon_list = [
 		id_weapon = "nun-chucks",
 		alias = [
 			"nanchacku",
+			"nunchaku",
+			"chucks",
 			"numchucks",
 			"nunchucks"
 		],
@@ -1759,6 +1763,7 @@ poi_list = [
 		id_poi = poi_id_stockexchange,
 		alias = [
 			"stocks",
+			"stock",
 			"exchange",
 			"sexchange",
 			"stockexchange",

--- a/ewleaderboard.py
+++ b/ewleaderboard.py
@@ -2,13 +2,15 @@ import datetime
 
 import ewcfg
 import ewutils
+from ew import EwMarket
 
 async def post_leaderboards(client = None, server = None):
 	leaderboard_channel = ewutils.get_channel(server = server, channel_name = ewcfg.channel_leaderboard)
 
-	time = str(datetime.datetime.now()).rpartition(':')[0]
+	market = EwMarket(id_server = server.id)
+	time = "day {}".format(market.day) 
 
-	await client.send_message(leaderboard_channel, "▓{} **STATE OF THE CITY** {} {}▓".format(ewcfg.emote_theeye, time, ewcfg.emote_theeye)) 
+	await client.send_message(leaderboard_channel, "▓▓{} **STATE OF THE CITY:** {} {}▓▓".format(ewcfg.emote_theeye, time, ewcfg.emote_theeye))
 
 	topslimes = make_userdata_board(server = server, category = ewcfg.col_slimes, title = ewcfg.leaderboard_slimes)
 	await client.send_message(leaderboard_channel, topslimes)
@@ -101,18 +103,27 @@ def format_board(entries = None, title = ""):
 def board_header(title):
 	emote = None
 
-	bar = " ▓▓▓▓▓▓▓ "
+	bar = " ▓▓▓▓▓"
 
 	if title == ewcfg.leaderboard_slimes:
 		emote = ewcfg.emote_slime2
+
+		bar += "▓▓▓ "
 	elif title == ewcfg.leaderboard_slimecredit:
 		emote = ewcfg.emote_slimecoin
+		bar += " "
 	elif title == ewcfg.leaderboard_ghosts:
 		emote = ewcfg.emote_negaslime
+
+		bar += "▓ "
 	elif title == ewcfg.leaderboard_bounty:
 		emote = ewcfg.emote_slimegun
+
+		bar += "▓ "
 	elif title == ewcfg.leaderboard_kingpins:
 		emote = ewcfg.emote_theeye
+
+		bar += " "
 
 	return emote + bar + title + bar + emote + "\n"
 

--- a/ewmap.py
+++ b/ewmap.py
@@ -593,8 +593,8 @@ async def move(cmd):
 					)
 			else:
 				if val > 0:
-					await asyncio.sleep(val/30) #fixme
-					#await asyncio.sleep(val)
+					#await asyncio.sleep(val/30) #fixme
+					await asyncio.sleep(val)
 
 """
 	Dump out the visual description of the area you're in.

--- a/ewmap.py
+++ b/ewmap.py
@@ -593,8 +593,8 @@ async def move(cmd):
 					)
 			else:
 				if val > 0:
-					#await asyncio.sleep(val/30) #fixme
-					await asyncio.sleep(val)
+					await asyncio.sleep(val/30) #fixme
+					#await asyncio.sleep(val)
 
 """
 	Dump out the visual description of the area you're in.

--- a/ewwep.py
+++ b/ewwep.py
@@ -263,6 +263,7 @@ async def attack(cmd):
 
 			if was_busted:
 				# Move around slime as a result of the shot.
+				user_data.change_slimes(n = (10 ** shootee_data.slimelevel) / 10)
 				market_data = EwMarket(id_server = cmd.message.server.id)
 				coinbounty = int(shootee_data.bounty / 1000)
 				user_data.slimecredit += coinbounty
@@ -723,6 +724,7 @@ async def equip(cmd):
 		value = None
 		if cmd.tokens_count > 1:
 			value = cmd.tokens[1]
+			value = value.lower()
 
 		weapon = ewcfg.weapon_map.get(value)
 		if weapon != None:


### PR DESCRIPTION
-'stock' as alias for stock exchange
-'nunchaku', 'chucks' as aliases for nunchucks
-!equip no longer case sensitive
-leaderboard category headers adjusted a little
-market now tracks a count of ingame days, going back to original EW launch day
-leaderboard header now shows ingame day number
-ghosts drop (10^level)/10 slime when busted
-casino open 24/7 
-!transfer works 24/7, with no cooldown
-you can now check other players' slimecoin amounts
-ghosts can gamble slimecoin
-new players start off alive