### PR TITLE
more stat tracking

### DIFF
--- a/README
+++ b/README
@@ -57,6 +57,7 @@ CREATE TABLE markets (
 	clock int NOT NULL DEFAULT '0',
 	weather varchar(32) NOT NULL DEFAULT 'sunny',
 	day int NOT NULL DEFAULT '726',
+	decayed_slimes bigint NOT NULL DEFAULT '0',
 
 	PRIMARY KEY (id_server)
 );

--- a/ew.py
+++ b/ew.py
@@ -19,6 +19,7 @@ class EwMarket:
 	boombust = 0
 	time_lasttick = 0
 	negaslime = 0
+	decayed_slimes = 0
 
 	""" Load the market data for this server from the database. """
 	def __init__(self, id_server = None):
@@ -31,7 +32,7 @@ class EwMarket:
 				cursor = conn.cursor();
 
 				# Retrieve object
-				cursor.execute("SELECT {}, {}, {}, {}, {}, {}, {}, {}, {}, {} FROM markets WHERE id_server = %s".format(
+				cursor.execute("SELECT {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {} FROM markets WHERE id_server = %s".format(
 					ewcfg.col_slimes_casino,
 					ewcfg.col_rate_market,
 					ewcfg.col_rate_exchange,
@@ -41,7 +42,8 @@ class EwMarket:
 					ewcfg.col_negaslime,
 					ewcfg.col_clock,
 					ewcfg.col_weather,
-					ewcfg.col_day
+					ewcfg.col_day,
+					ewcfg.col_decayed_slimes
 				), (self.id_server, ))
 				result = cursor.fetchone();
 
@@ -57,6 +59,7 @@ class EwMarket:
 					self.clock = result[7]
 					self.weather = result[8]
 					self.day = result[9]
+					self.decayed_slimes = result[10]
 				else:
 					# Create a new database entry if the object is missing.
 					cursor.execute("REPLACE INTO markets(id_server) VALUES(%s)", (id_server, ))
@@ -75,7 +78,7 @@ class EwMarket:
 			cursor = conn.cursor();
 
 			# Save the object.
-			cursor.execute("REPLACE INTO markets({}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}) VALUES(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)".format(
+			cursor.execute("REPLACE INTO markets({}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}) VALUES(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)".format(
 				ewcfg.col_id_server,
 				ewcfg.col_slimes_casino,
 				ewcfg.col_rate_market,
@@ -86,7 +89,8 @@ class EwMarket:
 				ewcfg.col_negaslime,
 				ewcfg.col_clock,
 				ewcfg.col_weather,
-				ewcfg.col_day
+				ewcfg.col_day,
+				ewcfg.col_decayed_slimes
 			), (
 				self.id_server,
 				self.slimes_casino,
@@ -98,7 +102,8 @@ class EwMarket:
 				self.negaslime,
 				self.clock,
 				self.weather,
-				self.day
+				self.day,
+				self.decayed_slimes
 			))
 
 			conn.commit()
@@ -149,34 +154,61 @@ class EwUser:
 			
 	""" gain or lose slime, recording statistics and potentially leveling up. """
 	def change_slimes(self, n = 0, source = None):
-		if source == ewcfg.source_damage:
-			self.totaldamage -= int(n) #minus a negative
-			ewstats.track_maximum(user = self, metric = ewcfg.stat_max_hitsurvived, value = int(n))
+		change = int(n)
+		self.slimes += change
 
-		if source == ewcfg.source_mining:
-			ewstats.change_stat(user = self, metric = ewcfg.stat_slimesmined, n = int(n))
+		if n >= 0:
+			ewstats.change_stat(user = self, metric = ewcfg.stat_lifetime_slimes, n = change)
+			ewstats.track_maximum(user = self, metric = ewcfg.stat_max_slimes, value = self.slimes)
 
-		if source == ewcfg.source_killing:
-			ewstats.change_stat(user = self, metric = ewcfg.stat_slimesfromkills, n = int(n))
+			if source == ewcfg.source_mining:
+				ewstats.change_stat(user = self, metric = ewcfg.stat_slimesmined, n = change)
+				ewstats.change_stat(user = self, metric = ewcfg.stat_lifetime_slimesmined, n = change)
 
-		self.slimes += int(n)
-		ewstats.track_maximum(user = self, metric = ewcfg.stat_max_slimes, value = self.slimes)
-		
-		#level up
+			if source == ewcfg.source_killing:
+				ewstats.change_stat(user = self, metric = ewcfg.stat_slimesfromkills, n = change) 
+				ewstats.change_stat(user = self, metric = ewcfg.stat_lifetime_slimesfromkills, n = change)
+		else:
+			change *= -1 # convert to positive number
+			if source != ewcfg.source_spending and source != ewcfg.source_ghostification:
+				ewstats.change_stat(user = self, metric = ewcfg.stat_lifetime_slimeloss, n = change)
+
+			if source == ewcfg.source_damage:
+				self.totaldamage += change
+				ewstats.track_maximum(user = self, metric = ewcfg.stat_max_hitsurvived, value = change)
+
+			if source == ewcfg.source_self_damage:
+				self.totaldamage += change
+				ewstats.change_stat(user = self, metric = ewcfg.stat_lifetime_selfdamage, n = change)
+
+			if source == ewcfg.source_decay:
+				ewstats.change_stat(user = self, metric = ewcfg.stat_lifetime_slimesdecayed, n = change)
+
+			if source == ewcfg.source_haunter:
+				ewstats.track_maximum(user = self, metric = ewcfg.stat_max_hauntinflicted, value = change)
+				ewstats.change_stat(user = self, metric = ewcfg.stat_lifetime_slimeshaunted, n = change)
+
+		# potentially level up
 		new_level = len(str(int(self.slimes)))
 		if self.life_state == ewcfg.life_state_corpse:
 			new_level -= 1 # because the minus sign in the slimes str throws the length off by 1
 		if new_level > self.slimelevel:
 			self.slimelevel = new_level
-			ewstats.track_maximum(user = self, metric = ewcfg.stat_max_level, value = self.slimelevel)
+			if self.life_state == ewcfg.life_state_corpse: 
+				ewstats.track_maximum(user = self, metric = ewcfg.stat_max_ghost_level, value = self.slimelevel)
+			else:
+				ewstats.track_maximum(user = self, metric = ewcfg.stat_max_level, value = self.slimelevel)
 		
-	def die(self):
-		if self.life_state != ewcfg.life_state_corpse: # don't count ghost deaths toward total deaths
+	def die(self, cause = None):
+		if cause == ewcfg.cause_busted:
+			self.busted = True
+		else:
 			self.busted = False  # reset busted state on normal death; potentially move this to ewspooky.revive
 			self.life_state = ewcfg.life_state_corpse
-			ewstats.change_stat(user = self, metric = ewcfg.stat_total_deaths, n = 1)
-		else:
-			self.busted = True  # this method is called for busted ghosts too
+			ewstats.increment_stat(user = self, metric = ewcfg.stat_lifetime_deaths)
+			ewstats.change_stat(user = self, metric = ewcfg.stat_lifetime_slimeloss, n = self.slimes)
+			if cause != ewcfg.cause_killing and cause != ewcfg.cause_suicide:
+				ewstats.increment_stat(user = self, metric = ewcfg.stat_lifetime_pve_deaths)
 		self.slimes = 0
 		self.poi = ewcfg.poi_id_thesewers
 		self.bounty = 0
@@ -195,6 +227,26 @@ class EwUser:
 	def add_bounty(self, n = 0):
 		self.bounty += int(n)
 		ewstats.track_maximum(user = self, metric = ewcfg.stat_max_bounty, value = self.bounty)
+
+	def change_slimecredit(self, n = 0, coinsource = None):
+		change = int(n)
+		self.slimecredit += change
+
+		if change >= 0:
+			ewstats.track_maximum(user = self, metric = ewcfg.stat_max_slimecredit, value = self.slimecredit)
+			ewstats.change_stat(user = self, metric = ewcfg.stat_lifetime_slimecredit, n = change)
+			if coinsource == ewcfg.coinsource_bounty:
+				ewstats.change_stat(user = self, metric = ewcfg.stat_bounty_collected, n = change)
+			if coinsource == ewcfg.coinsource_casino:
+				ewstats.track_maximum(user = self, metric = ewcfg.stat_biggest_casino_win, value = change)
+				ewstats.change_stat(user = self, metric = ewcfg.stat_lifetime_casino_winnings, n = change)
+		else:
+			change *= -1
+			if coinsource == ewcfg.coinsource_revival:
+				ewstats.change_stat(user = self, metric = ewcfg.stat_slimecredit_spent_on_revives, n = change)
+			if coinsource == ewcfg.coinsource_casino:
+				ewstats.track_maximum(user = self, metric = ewcfg.stat_biggest_casino_loss, value = change)
+				ewstats.change_stat(user = self, metric = ewcfg.stat_lifetime_casino_losses, n = change)
 
 	def add_weaponskill(self, n = 0):
 		# Save the current weapon's skill

--- a/ewcasino.py
+++ b/ewcasino.py
@@ -49,10 +49,6 @@ async def pachinko(cmd):
 		if value > user_data.slimecredit:
 			response = "You don't have enough SlimeCoin to play."
 		else:
-			#subtract slimecoin from player
-			user_data.slimecredit -= value
-			user_data.persist()
-
 			await cmd.client.edit_message(resp, ewutils.formatMessage(cmd.message.author, "You insert {:,} SlimeCoin. Balls begin to drop!".format(ewcfg.slimes_perpachinko)))
 			await asyncio.sleep(3)
 
@@ -87,8 +83,8 @@ async def pachinko(cmd):
 			# Significant time has passed since the user issued this command. We can't trust that their data hasn't changed.
 			user_data = EwUser(member = cmd.message.author)
 
-			# add winnings
-			user_data.slimecredit += winnings
+			# add winnings/subtract losses
+			user_data.change_slimecredit(n = winnings - value, coinsource = ewcfg.coinsource_casino)
 			user_data.persist()
 
 			if winnings > 0:
@@ -120,6 +116,7 @@ async def craps(cmd):
 	else:
 		last_crapsed_times[cmd.message.author.id] = time_now
 		value = None
+		winnings = 0
 
 		if cmd.tokens_count > 1:
 			value = ewutils.getIntToken(tokens = cmd.tokens, allow_all = True)
@@ -133,7 +130,6 @@ async def craps(cmd):
 			elif value > user_data.slimecredit:
 				response = "You don't have that much SlimeCoin to bet with."
 			else:
-				user_data.slimecredit -= value
 
 				roll1 = random.randint(1,6)
 				roll2 = random.randint(1,6)
@@ -152,10 +148,11 @@ async def craps(cmd):
 				if (roll1 + roll2) == 7:
 					winnings = 5 * value
 					response += "\n\n**You rolled a 7! It's your lucky day. You won {:,} SlimeCoin.**".format(winnings)
-					user_data.slimecredit += winnings
 				else:
 					response += "\n\nYou didn't roll 7. You lost your SlimeCoins."
 
+				# add winnings/subtract losses
+				user_data.change_slimecredit(n = winnings - value, coinsource = ewcfg.coinsource_casino)
 				user_data.persist()
 		else:
 			response = "Specify how much SlimeCoin you will wager."
@@ -188,10 +185,6 @@ async def slots(cmd):
 		if value > user_data.slimecredit:
 			response = "You don't have enough SlimeCoin."
 		else:
-			#subtract slimecoin from player
-			user_data.slimecredit -= value
-			user_data.persist()
-
 			# Add some suspense...
 			await cmd.client.edit_message(resp, ewutils.formatMessage(cmd.message.author, "You insert {:,} SlimeCoin and pull the handle...".format(ewcfg.slimes_perslot)))
 			await asyncio.sleep(3)
@@ -270,8 +263,8 @@ async def slots(cmd):
 			# Significant time has passed since the user issued this command. We can't trust that their data hasn't changed.
 			user_data = EwUser(member = cmd.message.author)
 
-			# add winnings
-			user_data.slimecredit += winnings
+			# add winnings/subtract losses
+			user_data.change_slimecredit(n = winnings - value, coinsource = ewcfg.coinsource_casino)
 			user_data.persist()
 
 		last_slotsed_times[cmd.message.author.id] = 0
@@ -326,8 +319,6 @@ async def roulette(cmd):
 					img_base + "sr.gif"
 				))
 
-				user_data.slimecredit -= value
-				user_data.persist()
 				await asyncio.sleep(5)
 
 				roll = str(random.randint(1, 38))
@@ -390,9 +381,8 @@ async def roulette(cmd):
 				# Assemble image file name.
 				response += "\n\n{}{}.gif".format(img_base, roll)
 
-				# add winnings
-				user_data = EwUser(member = cmd.message.author)
-				user_data.slimecredit += winnings
+				# add winnings/subtract losses
+				user_data.change_slimecredit(n = winnings - value, coinsource = ewcfg.coinsource_casino)
 				user_data.persist()
 		else:
 			response = "Specify how much SlimeCoin you will wager."

--- a/ewcfg.py
+++ b/ewcfg.py
@@ -300,6 +300,7 @@ col_negaslime = 'negaslime'
 col_clock = 'clock'
 col_weather = 'weather'
 col_day = 'day'
+col_decayed_slimes = 'decayed_slimes'
 
 # Database columns for stats
 col_total_slime = 'total_slime'
@@ -322,11 +323,6 @@ leaderboard_ghosts = "ANTI-SLIMIEST"
 leaderboard_podrins = "PODRIN LORDS"
 leaderboard_bounty = "MOST WANTED"
 leaderboard_kingpins = "KINGPINS' COFFERS"
-
-# Categories of events that change your slime total, for statistics tracking
-source_mining = 0
-source_damage = 1
-source_killing = 2
 
 # The highest level your weaponskill may be on revive. All skills over this level reset to this level.
 weaponskill_max_onrevive = 3
@@ -357,23 +353,78 @@ hitzone_list = [
 
 # User statistics we track 
 stat_max_slimes = 'max_slimes'
+stat_lifetime_slimes = 'lifetime_slimes'
+stat_lifetime_slimeloss = 'lifetime_slime_loss'
+stat_lifetime_slimesdecayed = 'lifetime_slimes_decayed'
 stat_slimesmined = 'slimes_mined'
-stat_slimesfromkills = 'slimes_from_kills'
 stat_max_slimesmined = 'max_slimes_mined'
+stat_lifetime_slimesmined = 'lifetime_slimes_mined'
+stat_slimesfromkills = 'slimes_from_kills'
 stat_max_slimesfromkills = 'max_slimes_from_kills'
+stat_lifetime_slimesfromkills = 'lifetime_slimes_from_kills'
+stat_lifetime_slimeshaunted = 'lifetime_slimes_haunted'
 stat_max_level = 'max_level'
+stat_max_ghost_level = 'max_ghost_level'
 stat_max_hitsurvived = 'max_hit_survived'
+stat_max_hitdealt = 'max_hit_dealt'
+stat_max_hauntinflicted = 'max_haunt_inflicted' 
 stat_kills = 'kills'
 stat_max_kills = 'max_kills'
+stat_biggest_kill = 'biggest_kill'
+stat_lifetime_kills = 'lifetime_kills'
+stat_lifetime_ganks = 'lifetime_ganks'
+stat_lifetime_takedowns = 'lifetime_takedowns'
 stat_max_wepskill = 'max_wep_skill'
 stat_max_slimecredit = 'max_slime_coins'
+stat_lifetime_slimecredit = 'lifetime_slime_coins'
+stat_slimecredit_spent_on_revives = 'slimecoins_spent_on_revives'
+stat_biggest_casino_win = 'biggest_casino_win'
+stat_biggest_casino_loss = 'biggest_casino_loss'
+stat_lifetime_casino_winnings = 'lifetime_casino_winnings'
+stat_lifetime_casino_losses = 'lifetime_casino_losses'
+stat_bounty_collected = 'bounty_collected'
 stat_max_bounty = 'max_bounty'
 stat_ghostbusts = 'ghostbusts'
+stat_biggest_bust_level = 'biggest_bust_level'
+stat_lifetime_ghostbusts = 'lifetime_ghostbusts'
 stat_max_ghostbusts = 'max_ghostbusts'
 stat_max_poudrins = 'max_poudrins'
-stat_total_damagedealt = 'total_damagedealt'
-stat_total_deaths = 'total_deaths'
+stat_poudrins_looted = 'poudrins_looted'
+stat_lifetime_poudrins = 'lifetime_poudrins'
+stat_lifetime_damagedealt = 'lifetime_damage_dealt'
+stat_lifetime_selfdamage = 'lifetime_self_damage'
+stat_lifetime_deaths = 'lifetime_deaths'
+stat_lifetime_pve_deaths = 'lifetime_pve_deaths'
 
+# Categories of events that change your slime total, for statistics tracking
+source_mining = 0
+source_damage = 1
+source_killing = 2
+source_self_damage = 3
+source_busting = 4
+source_haunter = 5
+source_haunted = 6
+source_spending = 7
+source_decay = 8
+source_ghostification = 9
+
+# Categories of events that change your slimecoin total, for statistics tracking
+coinsource_spending = 0
+coinsource_donation = 1
+coinsource_bounty = 2
+coinsource_revival = 3
+coinsource_casino = 4
+coinsource_transfer = 5
+
+# Causes of death, for statistics tracking
+cause_killing = 0
+cause_mining = 1
+cause_grandfoe = 2
+cause_donation = 3
+cause_busted = 4
+cause_suicide = 5
+
+# List of user statistics that reset to 0 on death
 stats_clear_on_death = [
 	stat_slimesmined,
 	stat_slimesfromkills,
@@ -418,7 +469,7 @@ def wef_nunchucks(ctn = None):
 		ctn.crit = True
 	elif ctn.strikes == 0:
 		ctn.miss = True
-		ctn.user_data.slimes -= int(ctn.slimes_damage / 2)
+		ctn.user_data.change_slimes(n = (-ctn.slimes_damage / 2), source = source_self_damage)
 
 # weapon effect function for "katana"
 def wef_katana(ctn = None):
@@ -477,7 +528,7 @@ def wef_molotov(ctn = None):
 
 	if aim <= 10:
 		ctn.crit = True
-		ctn.user_data.slimes -= ctn.slimes_damage
+		ctn.user_data.change_slimes(n = -ctn.slimes_damage, source = source_self_damage)
 	elif aim > 10 and aim <= 20:
 		ctn.miss = True
 		ctn.slimes_damage = 0
@@ -497,7 +548,7 @@ def wef_knives(ctn = None):
 
 # weapon effect function for "scythe"
 def wef_scythe(ctn = None):
-	ctn.user_data.slimes -= int(ctn.slimes_spent * 0.33)
+	ctn.user_data.change_slimes(n = (-ctn.slimes_spent * 0.33), source = source_self_damage)
 	ctn.slimes_damage = int(ctn.slimes_damage * 1.25)
 	aim = (random.randrange(10) + 1)
 

--- a/ewevent.py
+++ b/ewevent.py
@@ -1,6 +1,7 @@
 import ewutils
 import ewcfg
 import ewstats
+import ewitem
 
 """
 	Database persistence object describing some discrete event. Player
@@ -45,6 +46,9 @@ def init_stat_function_map():
 		ewcfg.stat_max_slimesfromkills: process_max_slimesfromkills,
 		ewcfg.stat_kills: process_kills,
 		ewcfg.stat_max_kills: process_max_kills,
+		ewcfg.stat_ghostbusts: process_ghostbusts,
+		ewcfg.stat_max_ghostbusts: process_max_ghostbusts,
+		ewcfg.stat_poudrins_looted: process_poudrins_looted
 	}
 	global fns_initialized
 	fns_initialized = True
@@ -74,7 +78,26 @@ def process_max_slimesfromkills(id_server = None, id_user = None, value = None):
 
 def process_kills(id_server = None, id_user = None, value = None):
 	ewstats.track_maximum(id_server = id_server, id_user = id_user, metric = ewcfg.stat_max_kills, value = value)
+	ewstats.increment_stat(id_server = id_server, id_user = id_user, metric = ewcfg.stat_lifetime_kills)
 
 def process_max_kills(id_server = None, id_user = None, value = None):
 	# TODO give apropriate medal
 	pass
+
+def process_ghostbusts(id_server = None, id_user = None, value = None):
+	ewstats.track_maximum(id_server = id_server, id_user = id_user, metric = ewcfg.stat_max_ghostbusts, value = value)
+	ewstats.increment_stat(id_server = id_server, id_user = id_user, metric = ewcfg.stat_lifetime_ghostbusts)
+
+def process_max_ghostbusts(id_server = None, id_user = None, value = None):
+	# TODO give apropriate medal
+	pass
+
+def process_poudrins_looted(id_server = None, id_user = None, value = None):
+	poudrins = ewitem.inventory(
+		id_user = id_user,
+		id_server = id_server,
+		item_type_filter = ewcfg.it_slimepoudrin
+	)
+	poudrins_count = len(poudrins)
+	ewstats.track_maximum(id_user = id_user, id_server = id_server, metric = ewcfg.stat_max_poudrins, value = poudrins_count)
+	ewstats.change_stat(id_user = id_user, id_server = id_server, metric = ewcfg.stat_lifetime_poudrins, n = value)

--- a/ewfood.py
+++ b/ewfood.py
@@ -118,7 +118,7 @@ async def order(cmd):
 					credits = user_data.slimecredit
 				)
 			else:
-				user_data.slimecredit -= value
+				user_data.change_slimecredit(n = -value, coinsource = ewcfg.coinsource_spending)
 
 				if target_data != None:
 					target_data.hunger -= food.recover_hunger

--- a/ewitem.py
+++ b/ewitem.py
@@ -1,5 +1,6 @@
 import ewutils
 import ewcfg
+import ewstats
 from ew import EwUser
 from ewplayer import EwPlayer
 
@@ -311,7 +312,21 @@ def item_loot(
 		conn = conn_info.get('conn')
 		cursor = conn.cursor()
 
-		# Create the item in the database.
+		# TODO more elegant solution for tracking this sort of thing -- get amount of poudrins taken for stat tracking
+		cursor.execute("SELECT * FROM items WHERE {id_server} = %s AND {id_user} = %s AND {item_type} = %s".format(
+			id_user = ewcfg.col_id_user,
+			id_server = ewcfg.col_id_server,
+			item_type = ewcfg.col_item_type,
+		), (
+			member.server.id,
+			member.id,
+			ewcfg.it_slimepoudrin
+		))
+		poudrins_looted = cursor.rowcount
+		ewutils.logMsg("Attempting to loot {} poudrins.".format(poudrins_looted))
+		ewstats.change_stat(id_server = member.server.id, id_user = id_user_target, metric = ewcfg.stat_poudrins_looted, n = poudrins_looted)
+
+		# Re-assign lootable items to looting user
 		cursor.execute("UPDATE items SET {id_user} = %s WHERE {id_server} = %s AND {id_user} = %s AND {soulbound} = 0".format(
 			id_user = ewcfg.col_id_user,
 			id_server = ewcfg.col_id_server,

--- a/ewjuviecmd.py
+++ b/ewjuviecmd.py
@@ -10,6 +10,7 @@ import ewcmd
 import ewitem
 import ewmap
 import ewrolemgr
+import ewstats
 from ew import EwUser, EwMarket
 
 # Map of user ID to a map of recent miss-mining time to count. If the count
@@ -108,7 +109,7 @@ async def mine(cmd):
 			if mismined['count'] >= 7:  # up to 6 messages can be buffered by discord and people have been dying unfairly because of that
 				# Death
 				last_mismined_times[cmd.message.author.id] = None
-				user_data.die()
+				user_data.die(cause = ewcfg.cause_mining)
 				user_data.persist()
 				
 				await cmd.client.send_message(cmd.message.channel, ewutils.formatMessage(cmd.message.author, "You have died in a mining accident."))
@@ -162,6 +163,8 @@ async def mine(cmd):
 					elif poudrinamount == 2:
 						response += "You unearthed two slime poudrins! "
 
+					ewstats.change_stat(user = user_data, metric = ewcfg.stat_lifetime_poudrins, n = poudrinamount)
+
 					ewutils.logMsg('{} has found {} poudrin(s)!'.format(cmd.message.author.display_name, poudrinamount))
 
 				if was_levelup:
@@ -192,7 +195,7 @@ async def mine(cmd):
 			# Death
 			last_mismined_times[cmd.message.author.id] = None
 
-			user_data.die()
+			user_data.die(cause = ewcfg.cause_mining)
 			user_data.persist()
 
 			await cmd.client.send_message(cmd.message.channel, ewutils.formatMessage(cmd.message.author, "You have died in a mining accident."))

--- a/ewmap.py
+++ b/ewmap.py
@@ -593,8 +593,8 @@ async def move(cmd):
 					)
 			else:
 				if val > 0:
-					await asyncio.sleep(val/30) #fixme
-					#await asyncio.sleep(val)
+					#await asyncio.sleep(val/30) 
+					await asyncio.sleep(val)
 
 """
 	Dump out the visual description of the area you're in.

--- a/ewmarket.py
+++ b/ewmarket.py
@@ -5,6 +5,7 @@ import ewitem
 import ewrolemgr
 import ewutils
 import ewcfg
+import ewstats
 from ew import EwUser, EwMarket
 
 """ donate slime to slimecorp in exchange for slimecoin """
@@ -39,7 +40,7 @@ async def donate(cmd):
 
 		if user_data.slimes < cost_total:
 			response = "Acid-green flashes of light and bloodcurdling screams emanate from small window of SlimeCorp HQ. Unfortunately, you did not survive the procedure. Your body is dumped down a disposal chute to the sewers."
-			user_data.die()
+			user_data.die(cause = ewcfg.cause_donation)
 			user_data.persist()
 			# Assign the corpse role to the player. He dead.
 			await ewrolemgr.updateRoles(client = cmd.client, member = cmd.message.author)
@@ -47,8 +48,8 @@ async def donate(cmd):
 			await cmd.client.send_message(sewerchannel, "{} ".format(ewcfg.emote_slimeskull) + ewutils.formatMessage(cmd.message.author, "You have died in a medical mishap. {}".format(ewcfg.emote_slimeskull)))
 		else:
 			# Do the transfer if the player can afford it.
-			user_data.slimes -= cost_total
-			user_data.slimecredit += coin_total
+			user_data.change_slimes(n = -cost_total, source = ewcfg.source_spending)
+			user_data.change_slimecredit(n = coin_total, coinsource = ewcfg.coinsource_donation)
 			user_data.time_lastinvest = time_now
 
 			# Persist changes
@@ -109,8 +110,8 @@ async def xfer(cmd):
 			response = "You don't have enough SlimeCoin. ({:,}/{:,})".format(user_data.slimecredit, cost_total)
 		else:
 			# Do the transfer if the player can afford it.
-			target_data.slimecredit += value
-			user_data.slimecredit -= cost_total
+			target_data.change_slimecredit(n = value, coinsource = ewcfg.coinsource_transfer)
+			user_data.change_slimecredit(n = -cost_total, coinsource = ewcfg.coinsource_transfer)
 			user_data.time_lastinvest = time_now
 
 			# Persist changes

--- a/ewraidboss.py
+++ b/ewraidboss.py
@@ -88,7 +88,7 @@ async def writhe(cmd):
 				user_data_target = EwUser(member = target)
 
 				user_data_target.id_killer = cmd.message.author.id
-				user_data_target.die()
+				user_data_target.die(cause = ewcfg.cause_grandfoe)
 				user_data_target.persist()
 				await ewrolemgr.updateRoles(client = cmd.client, member = target)
 				sewerchannel = ewutils.get_channel(cmd.message.server, ewcfg.channel_sewers)

--- a/ewspooky.py
+++ b/ewspooky.py
@@ -25,7 +25,7 @@ async def revive(cmd):
 
 			# Endless War collects his fee.
 			fee = (player_data.slimecredit / 10)
-			player_data.slimecredit -= fee
+			player_data.change_slimecredit(n = -fee, coinsource = ewcfg.coinsource_revival)
 			market_data.slimes_revivefee += fee
 			
 			# Preserve negaslime
@@ -113,8 +113,8 @@ async def haunt(cmd):
 			if -user_data.slimes < haunted_slimes:  # cap on for how much you can haunt
 				haunted_slimes = -user_data.slimes
 
-			haunted_data.change_slimes(n = -haunted_slimes)
-			user_data.change_slimes(n = -haunted_slimes)
+			haunted_data.change_slimes(n = -haunted_slimes, source = ewcfg.source_haunted)
+			user_data.change_slimes(n = -haunted_slimes, source = ewcfg.source_haunter)
 			user_data.time_lasthaunt = time_now
 
 			# Persist changes to the database.

--- a/ewstats.py
+++ b/ewstats.py
@@ -100,6 +100,9 @@ def change_stat(id_server = None, id_user = None, user = None, metric = None, n 
 		cursor.close()
 		ewutils.databaseClose(conn_info)
 
+def increment_stat(id_server = None, id_user = None, user = None, metric = None):
+	change_stat(id_server = id_server, id_user = id_user, user = user, metric = metric, n = 1)
+
 """ Update a user statistic only if the new value is higher. return True if change occurred """
 def track_maximum(id_server = None, id_user = None, user = None, metric = None, value = 0):
 	if(id_user == None) and (id_server == None):

--- a/ewutils.py
+++ b/ewutils.py
@@ -196,7 +196,7 @@ def databaseClose(conn_info):
 def formatMessage(user_target, message):
 	return "*{}*: {}".format(user_target.display_name, message).replace("@", "\{at\}")
 
-""" 0 slime totals for all users """
+""" Decay slime totals for all users """
 def decaySlimes(id_server = None):
 	if id_server != None:
 		try:

--- a/ewwep.py
+++ b/ewwep.py
@@ -415,7 +415,7 @@ async def attack(cmd):
 						ewstats.increment_stat(user = user_data, metric = ewcfg.stat_lifetime_takedowns)
 
 					# Move around slime as a result of the shot.
-					if shootee_data.slimes > 0:
+					if shootee_data.slimes >= 0:
 						if was_juvenile:
 							user_data.change_slimes(n = slimes_dropped, source = ewcfg.source_killing)
 						else:

--- a/ewwep.py
+++ b/ewwep.py
@@ -419,10 +419,12 @@ async def attack(cmd):
 						if was_juvenile:
 							user_data.change_slimes(n = slimes_dropped, source = ewcfg.source_killing)
 						else:
-							coinbounty = int(shootee_data.bounty / 1000)  # 1000 slime per coin
 							user_data.change_slimecredit(n = coinbounty, coinsource = ewcfg.coinsource_bounty)
 							user_data.change_slimes(n = slimes_dropped / 2, source = ewcfg.source_killing)
 							boss_slimes += int(slimes_dropped / 2)
+
+					# Collect bounty		
+					coinbounty = int(shootee_data.bounty / 1000)  # 1000 slime per coin
 
 					# Steal items
 					ewitem.item_loot(member = member, id_user_target = cmd.message.author.id)


### PR DESCRIPTION
Adds a ton more categories of stat tracking. See block of stat names in ewcfg.
A running total of all slime taken by decay is kept in market data. (new column!)

minor bugfix: fixed a bug that prevented bounty or slime from being collected on a kill if the victim had 0 slimes at moment of death (perhaps by donating everything)

important changes to methods that change an ewuser:
-EwUser.die() now takes a cause argument (from ewcfg) 
-add remove slimecoin from user with EwUser.change_slimecredit()
-a lot more source descriptors have been added for change_slimes()

