### PR TITLE
Territory Control spring cleaning

### DIFF
--- a/ewcfg.py
+++ b/ewcfg.py
@@ -291,10 +291,10 @@ property_class_c = "c"
 
 # district capturing
 capture_tick_length = 10  # in seconds; also affects how much progress is made per tick so that 1 second = 1 capture point
-max_capture_points_s = 3600  # 60 min
-max_capture_points_a = 1800  # 30 min
-max_capture_points_b = 1200  # 20 min
-max_capture_points_c = 600   # 10 min
+max_capture_points_s = 7200  # 120 min
+max_capture_points_a = 3600  # 60 min
+max_capture_points_b = 1800  # 30 min
+max_capture_points_c = 900   # 15 min
 
 # district capture rates assigned to property classes
 max_capture_points = {
@@ -305,21 +305,24 @@ max_capture_points = {
 }
 
 # capture messages
-capture_milestone = 10  # after how many percent of progress the players are notified of the progress
+capture_milestone = 5  # after how many percent of progress the players are notified of the progress
 
 
 # district de-capturing
 decapture_speed_multiplier = 2  # how much faster de-capturing is than capturing
+
+# district control decay
+decay_modifier = 2  # more means slower
 
 # time values
 seconds_per_ingame_day = 21600
 ticks_per_day = seconds_per_ingame_day / update_market  # how often the kingpins receive slime per in-game day
 
 # kingpin district control slime yields (per tick, i.e. in-game-hourly)
-slime_yield_class_s = int(30000 / ticks_per_day)  # dividing the daily amount by the amount of method calls per day
-slime_yield_class_a = int(20000 / ticks_per_day)
-slime_yield_class_b = int(15000 / ticks_per_day)
-slime_yield_class_c = int(10000 / ticks_per_day)
+slime_yield_class_s = int(60000 / ticks_per_day)  # dividing the daily amount by the amount of method calls per day
+slime_yield_class_a = int(40000 / ticks_per_day)
+slime_yield_class_b = int(30000 / ticks_per_day)
+slime_yield_class_c = int(20000 / ticks_per_day)
 
 # district control slime yields assigned to property classes
 district_control_slime_yields = {

--- a/ewdistrict.py
+++ b/ewdistrict.py
@@ -104,7 +104,7 @@ class EwDistrict:
 			if not cap_faction_member_present:  # only decay if no members of the currently capturing (or controlling) faction are present
 
 				# reduces the capture progress at a rate with which it arrives at 0 after 1 in-game day
-				await self.change_capture_points(-math.ceil(self.max_capture_points / ewcfg.ticks_per_day), ewcfg.actor_decay)
+				await self.change_capture_points(-math.ceil(self.max_capture_points / (ewcfg.ticks_per_day * ewcfg.decay_modifier)), ewcfg.actor_decay)
 
 		if self.capture_points < 0:
 			self.capture_points = 0
@@ -319,11 +319,12 @@ async def capture_tick(id_server):
 
 		all_districts = cursor.fetchall()
 
-		cursor.execute("SELECT {poi}, {faction}, {life_state}, {id_user} FROM users WHERE id_server = %s AND {life_state} > 1".format(
+		cursor.execute("SELECT {poi}, {faction}, {life_state}, {id_user}, {slimes} FROM users WHERE id_server = %s AND {life_state} > 1".format(
 			poi = ewcfg.col_poi,
 			faction = ewcfg.col_faction,
 			life_state = ewcfg.col_life_state,
-			id_user = ewcfg.col_id_user
+			id_user = ewcfg.col_id_user,
+			slimes = ewcfg.col_slimes
 		), (
 			id_server,
 		))
@@ -359,6 +360,7 @@ async def capture_tick(id_server):
 				player_faction = player[1]
 				player_life_state = player[2]
 				player_id = player[3]
+				player_slimes = player[4]
 
 				if player_poi == district_name and player_life_state == ewcfg.life_state_enlisted:  # if the player is in the district and a gang member
 					try:
@@ -368,7 +370,7 @@ async def capture_tick(id_server):
 
 					#ewutils.logMsg("Online status checked. Time elapsed: %f" % (time.time() - time_old) + " Server: %s" % id_server + " Player: %s" % player_id + " Status: %s" % ("online" if player_online else "offline"))
 
-					if player_online:
+					if player_online and player_slimes >= 10000:
 						if faction_capture != None and faction_capture != player_faction:  # if someone of the opposite faction is in the district
 							faction_capture = 'both'  # standstill, gang violence has to happen
 							capture_speed = 0


### PR DESCRIPTION
-Increased Kingpin slime gain from captured districts
-Increased time needed to capture districts
-Increased how often your progress capturing a district is reported
-Decreased decay rate for captured districts
- Players now have to have at least 10k slime to participate in territory control

it's tested as well as i can do that. didn't measure any times or so.